### PR TITLE
feature(PocoException): Add poco object attribute to the exception

### DIFF
--- a/poco/exceptions.py
+++ b/poco/exceptions.py
@@ -51,7 +51,9 @@ class PocoTargetTimeout(PocoException):
 
     def __init__(self, action, poco_obj_proxy):
         super(PocoTargetTimeout, self).__init__()
-        self.message = 'Waiting timeout for {} of "{}"'.format(action, to_text(repr(poco_obj_proxy)))
+        poco_obj_proxy_string = to_text(repr(poco_obj_proxy))
+        self.poco_object_proxy_string = poco_obj_proxy_string
+        self.message = 'Waiting timeout for {} of "{}"'.format(action, poco_obj_proxy_string)
 
 
 class PocoNoSuchNodeException(PocoException):
@@ -61,7 +63,9 @@ class PocoNoSuchNodeException(PocoException):
 
     def __init__(self, objproxy):
         super(PocoNoSuchNodeException, self).__init__()
-        self.message = 'Cannot find any visible node by query {}'.format(to_text(repr(objproxy)))
+        obj_proxy_string = to_text(repr(objproxy))
+        self.poco_object_proxy_string = obj_proxy_string
+        self.message = 'Cannot find any visible node by query {}'.format(obj_proxy_string)
 
 
 class PocoTargetRemovedException(PocoException):


### PR DESCRIPTION
**CONTEXT**
So far the `PocoHierarchy parser` needs a util function to parse the object name from the exception message which is not completely reliable. This stores the object name as is, simplifies it and makes it reliable.